### PR TITLE
Added the ability to tail files from a connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hussh"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ conn.sftp_read(remote_path="/dest/path/file", local_path="/path/to/my/file")
 contents = conn.sftp_read(remote_path="/dest/path/file")
 ```
 
+## Copy files from one connection to another
+Hussh offers a shortcut that allows you to copy a file between two established connections.
+```python
+source_conn = Connection("my.first.server")
+dest_conn = Connection("my.second.server", password="secret")
+# Copy from source to destination
+source_conn.remote_copy(source_path="/root/myfile.txt", dest_conn=dest_conn)
+```
+By default, if you don't pass in an alternate `dest_path`, Hussh will copy it to the same path as it came from on source.
+
+
 # SCP
 For remote servers that support SCP, Hussh can do that to.
 
@@ -95,16 +106,15 @@ conn.scp_read(remote_path="/dest/path/file", local_path="/path/to/my/file")
 contents = conn.scp_read(remote_path="/dest/path/file")
 ```
 
-## Copy files from one connection to another
-Hussh offers a shortcut that allows you to copy a file between two established connections.
+# Tailing Files
+Hussh offers a built-in method for tailing files on a `Connection` with the `tail` method.
 ```python
-source_conn = Connection("my.first.server")
-dest_conn = Connection("my.second.server", password="secret")
-# Copy from source to destination
-source_conn.remote_copy(source_path="/root/myfile.txt", dest_conn=dest_conn)
+with conn.tail("/path/to/file.txt") as tf:
+   # perform some actions or wait
+   print(tf.read())  # at any time, you can read any unread contents
+   # when you're done tailing, exit the context manager
+print(tf.tailed_contents)
 ```
-By default, if you don't pass in an alternate `dest_path`, Hussh will copy it to the same path as it came from on source.
-
 
 # Interactive Shell
 If you need to keep a shell open to perform more complex interactions, you can get an `InteractiveShell` instance from the `Connection` class instance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ fn hussh(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<connection::Connection>()?; // Add the Connection class
     m.add_class::<connection::SSHResult>()?;
     // m.add_class::<connection::InteractiveShell>()?;
+    // m.add_class::<connection::FileTailer>()?;
     m.add(
         "AuthenticationError",
         _py.get_type_bound::<AuthenticationError>(),

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -163,3 +163,13 @@ def test_remote_copy(conn, run_second_server):
     dest_conn = Connection(host="localhost", port=8023, password="toor")
     conn.remote_copy("/root/hp.txt", dest_conn)
     assert "hp.txt" in dest_conn.execute("ls /root").stdout
+
+
+def test_tail(conn):
+    """Test that we can tail a file."""
+    conn.scp_write_data("hello\nworld\n", "/root/hello.txt")
+    with conn.tail("/root/hello.txt") as tf:
+        assert tf.read(0) == "hello\nworld\n"
+        assert tf.last_pos == 12
+        conn.execute("echo goodbye >> /root/hello.txt")
+    assert tf.tailed_contents == "goodbye\n"


### PR DESCRIPTION
This commit introduces one of the last major pieces for Connection, the ability to trigger a tail.
I'm undecided if I want to expose the FileTailer class, so we'll leave it out for now.
Also, the names of the attributes are subject to change pending feedback.