### PR TITLE
Better handling for exit in pty shells

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hussh"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pexpect",
     "pre-commit",
     "pytest",
+    "pytest-randomly",
     "ruff",
 ]
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -149,6 +149,16 @@ def test_shell_context(conn):
     assert sh.exit_result.status != 0
 
 
+def test_pty_shell_context(conn):
+    """Test that we can run multiple commands in a pty shell context."""
+    with conn.shell(pty=True) as sh:
+        sh.send("echo test shell")
+        sh.send("bad command")
+    assert "test shell" in sh.exit_result.stdout
+    assert "command not found" in sh.exit_result.stdout
+    assert sh.exit_result.status != 0
+
+
 def test_connection_timeout():
     """Test that we can trigger a timeout on connect."""
     with pytest.raises(TimeoutError):


### PR DESCRIPTION
Handled a condition where pty shells would hang on exit. This is currently resolved by explicitly passing "exit" to the channel when exiting the context manager. I'm sure there are better ways to handle this, but this works for now.