### PR TITLE
Changed FileTailer.tailed_contents to FileTailer.contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ with conn.tail("/path/to/file.txt") as tf:
    # perform some actions or wait
    print(tf.read())  # at any time, you can read any unread contents
    # when you're done tailing, exit the context manager
-print(tf.tailed_contents)
+print(tf.contents)
 ```
 
 # Interactive Shell

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -471,7 +471,7 @@ impl Connection {
     ///     time.sleep(5)  # wait or perform other operations
     ///     print(tailer.read())
     ///     time.sleep(5)  # wait or perform other operations
-    /// print(tailer.tailed_contents)
+    /// print(tailer.contents)
     /// ```
     fn tail(&self, remote_file: String) -> FileTailer {
         FileTailer::new(self, remote_file, None)
@@ -591,7 +591,7 @@ impl InteractiveShell {
 /// * `remote_file`: A string representing the path to the remote file.
 /// * `init_pos`: An optional initial position from where to start reading the file.
 /// * `last_pos`: The last position read from the file.
-/// * `tailed_contents`: The contents read from the file.
+/// * `contents`: The contents read from the file.
 ///
 /// # Methods
 ///
@@ -609,7 +609,7 @@ struct FileTailer {
     #[pyo3(get)]
     last_pos: u64,
     #[pyo3(get)]
-    tailed_contents: Option<String>,
+    contents: Option<String>,
 }
 
 #[pymethods]
@@ -621,7 +621,7 @@ impl FileTailer {
             remote_file,
             init_pos,
             last_pos: 0,
-            tailed_contents: None,
+            contents: None,
         }
     }
 
@@ -664,7 +664,7 @@ impl FileTailer {
         _exc_value: Option<&Bound<'_, PyAny>>,
         _traceback: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<()> {
-        self.tailed_contents = Some(self.read(self.init_pos));
+        self.contents = Some(self.read(self.init_pos));
         Ok(())
     }
 }

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -184,4 +184,4 @@ def test_tail(conn):
         assert tf.read(0) == TEST_STR
         assert tf.last_pos == len(TEST_STR)
         conn.execute("echo goodbye >> /root/hello.txt")
-    assert tf.tailed_contents == "goodbye\n"
+    assert tf.contents == "goodbye\n"


### PR DESCRIPTION
After some feedback, the named has been changed to reduce redundancy.