### PR TITLE
Change InteractiveShell's exit_result to result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hussh"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ print(tf.contents)
 # Interactive Shell
 If you need to keep a shell open to perform more complex interactions, you can get an `InteractiveShell` instance from the `Connection` class instance.
 To use the interactive shell, it is recommended to use the `shell()` context manager from the `Connection` class.
-You can send commands to the shell using the `send` method, then get the results from `exit_result` when you exit the context manager.
+You can send commands to the shell using the `send` method, then get the results from `result` when you exit the context manager.
 
 ```python
 with conn.shell() as shell:
@@ -151,7 +151,7 @@ with conn.shell() as shell:
    shell.send("pwd")
    shell.send("whoami")
 
-print(shell.exit_result.stdout)
+print(shell.result.stdout)
 ```
 **Note:** The `read` method sends an EOF to the shell, so you won't be able to send more commands after calling `read`. If you want to send more commands, you would need to create a new `InteractiveShell` instance.
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -41,7 +41,7 @@
 //! If you don't pass a username, "root" is used.
 //!
 //! To use the interactive shell, it is recommended to use the shell() context manager from the Connection class.
-//! You can send commands to the shell using the `send` method, then get the results from exit_result when you exit the context manager.
+//! You can send commands to the shell using the `send` method, then get the results from result when you exit the context manager.
 //! Due to the nature of reading from the shell, do not use the `read` method if you want to send more commands.
 //!
 //! ```python
@@ -50,7 +50,7 @@
 //!    shell.send("pwd")
 //!    shell.send("whoami")
 //!
-//! print(shell.exit_result.stdout)
+//! print(shell.result.stdout)
 //! ```
 //!
 //! Note: The `read` method sends an EOF to the shell, so you won't be able to send more commands after calling `read`. If you want to send more commands, you would need to create a new `InteractiveShell` instance.
@@ -491,7 +491,7 @@ impl Connection {
     /// with conn.shell() as shell:
     ///     shell.send("ls")
     ///     shell.send("pwd")
-    /// print(shell.exit_result.stdout)
+    /// print(shell.result.stdout)
     /// ```
     fn shell(&self, pty: Option<bool>) -> PyResult<InteractiveShell> {
         let mut channel = self.session.channel_session().unwrap();
@@ -504,7 +504,7 @@ impl Connection {
         Ok(InteractiveShell {
             channel: ChannelWrapper { channel },
             pty: pty.unwrap_or(false),
-            exit_result: None,
+            result: None,
         })
     }
 }
@@ -521,7 +521,7 @@ struct InteractiveShell {
     channel: ChannelWrapper,
     pty: bool,
     #[pyo3(get)]
-    exit_result: Option<SSHResult>,
+    result: Option<SSHResult>,
 }
 
 #[pymethods]
@@ -531,7 +531,7 @@ impl InteractiveShell {
         InteractiveShell {
             channel,
             pty,
-            exit_result: None,
+            result: None,
         }
     }
 
@@ -575,7 +575,7 @@ impl InteractiveShell {
         if self.pty {
             self.send("exit\n".to_string(), Some(false)).unwrap();
         }
-        self.exit_result = Some(self.read());
+        self.result = Some(self.read());
         Ok(())
     }
 }

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -144,9 +144,9 @@ def test_shell_context(conn):
     with conn.shell() as sh:
         sh.send("echo test shell")
         sh.send("bad command")
-    assert "test shell" in sh.exit_result.stdout
-    assert "command not found" in sh.exit_result.stderr
-    assert sh.exit_result.status != 0
+    assert "test shell" in sh.result.stdout
+    assert "command not found" in sh.result.stderr
+    assert sh.result.status != 0
 
 
 def test_pty_shell_context(conn):
@@ -154,9 +154,9 @@ def test_pty_shell_context(conn):
     with conn.shell(pty=True) as sh:
         sh.send("echo test shell")
         sh.send("bad command")
-    assert "test shell" in sh.exit_result.stdout
-    assert "command not found" in sh.exit_result.stdout
-    assert sh.exit_result.status != 0
+    assert "test shell" in sh.result.stdout
+    assert "command not found" in sh.result.stdout
+    assert sh.result.status != 0
 
 
 def test_connection_timeout():


### PR DESCRIPTION
This simplifies the attribute and brings it in line with a standard set by Broker.