### PR TITLE
Add a timeout to Connection.execute

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,6 +55,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - name: Temporary fix for openssl regression #25366
+        run: cargo update openssl-src --precise 300.3.1+3.3.1
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hussh"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -159,10 +159,16 @@ def test_pty_shell_context(conn):
     assert sh.result.status != 0
 
 
-def test_connection_timeout():
-    """Test that we can trigger a timeout on connect."""
+def test_session_timeout():
+    """Test that we can trigger a timeout on session handshake."""
     with pytest.raises(TimeoutError):
         Connection(host="localhost", port=8022, password="toor", timeout=10)
+
+
+def test_command_timeout(conn):
+    """Test that we can trigger a timeout on command execution."""
+    with pytest.raises(TimeoutError):
+        conn.execute("sleep 5", timeout=3000)
 
 
 def test_remote_copy(conn, run_second_server):


### PR DESCRIPTION
Previously the only way to set a timeout for commands was to do it upon Connection class creation. Now, we can set a timeout just for the scope of a command execution.

Additionally, I added better handling of potential timeouts as a result of this.