### PR TITLE
Revert temporary fix for openssl

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,8 +66,6 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
-      - name: Temporary fix for openssl regression #25366
-        run: cargo update openssl-src --precise 300.3.1+3.3.1
       - uses: actions/setup-python@v5
         with:
           python-version-file: 'pyproject.toml'
@@ -124,8 +122,6 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@v4
-      - name: Temporary fix for openssl regression #25366
-        run: cargo update openssl-src --precise 300.3.1+3.3.1
       - uses: actions/setup-python@v5
         with:
           python-version-file: 'pyproject.toml'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,6 +64,13 @@ jobs:
           #   target: s390x
           - runner: ubuntu-latest
             target: ppc64le
+    services:
+      hussh-test-server:
+        image: ghcr.io/jacobcallahan/hussh/hussh-test-server:latest
+        options: >-
+          --name hussh-test-server
+        ports:
+          - 8022:22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -120,6 +127,13 @@ jobs:
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
+    services:
+      hussh-test-server:
+        image: ghcr.io/jacobcallahan/hussh/hussh-test-server:latest
+        options: >-
+          --name hussh-test-server
+        ports:
+          - 8022:22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -200,7 +214,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
           pre-commit run --all-files
 
   sdist:
+    needs: [code_checks]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +40,7 @@ jobs:
           path: dist
 
   linux:
+    needs: [code_checks]
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -56,6 +58,13 @@ jobs:
           #   target: s390x
           - runner: ubuntu-latest
             target: ppc64le
+    services:
+      hussh-test-server:
+        image: ghcr.io/jacobcallahan/hussh/hussh-test-server:latest
+        options: >-
+          --name hussh-test-server
+        ports:
+          - 8022:22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -70,6 +79,7 @@ jobs:
           OPENSSL_NO_VENDOR: 1
         with:
           target: ${{ matrix.platform.target }}
+          # args: --release --out dist --find-interpreter  <-- TODO: Add this back when maturin supports it
           args: --release --out dist -i 3.8 3.9 3.10 3.11 3.12 3.13 pypy3.9 pypy3.10
           # sccache: 'true'
           manylinux: auto
@@ -90,8 +100,15 @@ jobs:
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: dist
+      - name: Install and Test
+        shell: bash
+        run: |
+          set -e
+          pip install .[dev] --find-links dist --force-reinstall
+          pytest -v tests/
 
   musllinux:
+    needs: [code_checks]
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -104,6 +121,13 @@ jobs:
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
+    services:
+      hussh-test-server:
+        image: ghcr.io/jacobcallahan/hussh/hussh-test-server:latest
+        options: >-
+          --name hussh-test-server
+        ports:
+          - 8022:22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -133,8 +157,15 @@ jobs:
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
+      - name: Install and Test
+        shell: bash
+        run: |
+          set -e
+          pip install .[dev] --find-links dist --force-reinstall
+          pytest -v tests/
 
   windows:
+    needs: [code_checks]
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -172,11 +203,12 @@ jobs:
           path: dist
 
   macos:
+    needs: [code_checks]
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,6 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
-      - name: Temporary fix for openssl regression #25366
-        run: cargo update openssl-src --precise 300.3.1+3.3.1
       - uses: actions/setup-python@v5
         with:
           python-version-file: 'pyproject.toml'
@@ -108,8 +106,6 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@v4
-      - name: Temporary fix for openssl regression #25366
-        run: cargo update openssl-src --precise 300.3.1+3.3.1
       - uses: actions/setup-python@v5
         with:
           python-version-file: 'pyproject.toml'

--- a/.github/workflows/update_test_server.yaml
+++ b/.github/workflows/update_test_server.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     # Login to GitHub Container Registry only on push events
     - name: Login to GitHub Container Registry

--- a/.github/workflows/update_test_server.yaml
+++ b/.github/workflows/update_test_server.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
       with:
-        context: .
-        # Conditionally push based on the event type
-        push: ${{ github.event_name == 'push' }}
-        tags: ghcr.io/jacobcallahan/hussh/hussh-test-server:latest
+          context: ./tests/setup
+          # Conditionally push based on the event type
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/jacobcallahan/hussh/hussh-test-server:latest

--- a/.github/workflows/update_test_server.yaml
+++ b/.github/workflows/update_test_server.yaml
@@ -30,7 +30,7 @@ jobs:
 
     # Build and push Docker image
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         # Conditionally push based on the event type

--- a/.github/workflows/update_test_server.yaml
+++ b/.github/workflows/update_test_server.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/update_test_server.yaml
+++ b/.github/workflows/update_test_server.yaml
@@ -22,7 +22,7 @@ jobs:
     # Login to GitHub Container Registry only on push events
     - name: Login to GitHub Container Registry
       if: github.event_name == 'push'
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: jacobcallahan

--- a/.github/workflows/weekly_build_and_test.yml
+++ b/.github/workflows/weekly_build_and_test.yml
@@ -64,8 +64,6 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
-      - name: Temporary fix for openssl regression #25366
-        run: cargo update openssl-src --precise 300.3.1+3.3.1
       - uses: actions/setup-python@v5
         with:
           python-version-file: 'pyproject.toml'
@@ -121,8 +119,6 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@v4
-      - name: Temporary fix for openssl regression #25366
-        run: cargo update openssl-src --precise 300.3.1+3.3.1
       - uses: actions/setup-python@v5
         with:
           python-version-file: 'pyproject.toml'

--- a/.github/workflows/weekly_build_and_test.yml
+++ b/.github/workflows/weekly_build_and_test.yml
@@ -62,6 +62,13 @@ jobs:
           #   target: s390x
           - runner: ubuntu-latest
             target: ppc64le
+    services:
+      hussh-test-server:
+        image: ghcr.io/jacobcallahan/hussh/hussh-test-server:latest
+        options: >-
+          --name hussh-test-server
+        ports:
+          - 8022:22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -76,6 +83,7 @@ jobs:
           OPENSSL_NO_VENDOR: 1
         with:
           target: ${{ matrix.platform.target }}
+          # args: --release --out dist --find-interpreter  <-- TODO: Add this back when maturin supports it
           args: --release --out dist -i 3.8 3.9 3.10 3.11 3.12 3.13 pypy3.9 pypy3.10
           # sccache: 'true'
           manylinux: auto
@@ -117,6 +125,13 @@ jobs:
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
+    services:
+      hussh-test-server:
+        image: ghcr.io/jacobcallahan/hussh/hussh-test-server:latest
+        options: >-
+          --name hussh-test-server
+        ports:
+          - 8022:22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -197,9 +212,11 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
           - runner: macos-14
+            target: aarch64
+          - runner: macos-15
             target: aarch64
     steps:
       - uses: actions/checkout@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,9 @@ def run_test_server(ensure_test_server_image):
     client = docker.from_env()
     try:  # check to see if the container is already running
         container = client.containers.get("hussh-test-server")
+        if container.status != "running":
+            container.start()
+            time.sleep(5)  # give the server time to start
         managed = False
     except docker.errors.NotFound:  # if not, start it
         container = client.containers.run(

--- a/tests/setup/Dockerfile
+++ b/tests/setup/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 RUN dnf -y update && dnf -y install openssh-server openssh-clients
-RUN mkdir /var/run/sshd
+RUN mkdir -p /var/run/sshd
 RUN echo 'root:toor' | chpasswd
 RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config


### PR DESCRIPTION
openssl #25366 has been included in the latest version of openssl, so let's remove this step and see how it goes.